### PR TITLE
Cleaning up the auth part and some config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Since this uses federation we cannot use it locally, for this we will use a bot 
 
    ```
 
-2. On the Azure Bot (for local/debug: devops-debug-bot), select **Settings**, then **Configuration**, and update the **Messaging endpoint** to `{tunnel-url}/api/messages` eg: `https://kw238403-3978.eun1.devtunnels.ms/api/messages`
+2. On the Azure Bot (for local/debug: devops-debug-bot), select **Settings**, then **Configuration**, and update the **Messaging endpoint** to `{tunnel-url}/api/messages` eg: `https://kw238403-3978.eun1.devtunnels.ms/devops-teams-notification-api/api/messages`
 3. Change the secret of the appsettings.local, you can find this in the keyvault under `devops-debug-bot-secret`, the client-id and tenant is already setup
 4. Run the application
 5. Add the bot to teams, select **Settings**, then **Channels**, and click on the link **Open in Teams**

--- a/src/Teams.Notifications.Api/DelegatingHandlers/RequestAndResponseLoggerHandler.cs
+++ b/src/Teams.Notifications.Api/DelegatingHandlers/RequestAndResponseLoggerHandler.cs
@@ -10,7 +10,7 @@ namespace Teams.Notifications.Api.DelegatingHandlers;
 public class RequestAndResponseLoggerHandler(ILogger<RequestAndResponseLoggerHandler> logger) : DelegatingHandler
 {
     private const int MaxBodyLength = 10000; // we don't want to log  big request or responses
-    private static readonly bool ShouldLog = true;
+    private static readonly bool ShouldLog = false;
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
         CancellationToken cancellationToken

--- a/src/Teams.Notifications.Api/DelegatingHandlers/RequestAndResponseLoggerHandler.cs
+++ b/src/Teams.Notifications.Api/DelegatingHandlers/RequestAndResponseLoggerHandler.cs
@@ -10,7 +10,7 @@ namespace Teams.Notifications.Api.DelegatingHandlers;
 public class RequestAndResponseLoggerHandler(ILogger<RequestAndResponseLoggerHandler> logger) : DelegatingHandler
 {
     private const int MaxBodyLength = 10000; // we don't want to log  big request or responses
-    private static readonly bool ShouldLog = false;
+    private static readonly bool ShouldLog = true;
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
         CancellationToken cancellationToken

--- a/src/Teams.Notifications.Api/Extensions/AspNetExtensions.cs
+++ b/src/Teams.Notifications.Api/Extensions/AspNetExtensions.cs
@@ -120,7 +120,4 @@ internal static class AspNetExtensions
                 };
             });
     }
-
-   
-    
 }

--- a/src/Teams.Notifications.Api/Models/FileErrorModel.cs
+++ b/src/Teams.Notifications.Api/Models/FileErrorModel.cs
@@ -47,7 +47,8 @@ public sealed record FileErrorModel
     /// <example>StackTrace: Found and error in </example>
     [FromForm]
     [JsonPropertyName("errorMessage")]
-    public string ErrorMessage { get; set; } = string.Empty;
+
+    public string? ErrorMessage { get; set; } 
 
     /// <summary>
     ///     When the file originally went into error

--- a/src/Teams.Notifications.Api/MsalAuthChanged.cs
+++ b/src/Teams.Notifications.Api/MsalAuthChanged.cs
@@ -26,9 +26,13 @@ public class MsalAuthChanged : IAccessTokenProvider, IMSALProvider
         var config = systemServiceProvider.GetRequiredService<IConfiguration>();
         _clientId = config["AZURE_CLIENT_ID"] ?? throw new NoNullAllowedException("ClientId is required");
         _tenantId = config["AZURE_TENANT_ID"] ?? throw new NoNullAllowedException("TenantId is required");
+        _host = config["AZURE_AUTHORITY_HOST"] ?? throw new NoNullAllowedException("host is required");
         _clientSecret = config["ClientSecret"];
-        _host = config["AZURE_AUTHORITY_HOST"];
         _federatedTokenFile = config["AZURE_FEDERATED_TOKEN_FILE"];
+        if (string.IsNullOrWhiteSpace(_clientSecret) && string.IsNullOrWhiteSpace(_federatedTokenFile))
+        {
+            throw new NoNullAllowedException("Secret or token file is required");
+        }
     }
 
 

--- a/src/Teams.Notifications.Api/MsalAuthChanged.cs
+++ b/src/Teams.Notifications.Api/MsalAuthChanged.cs
@@ -18,6 +18,7 @@ public class MsalAuthChanged : IAccessTokenProvider, IMSALProvider
     private readonly string _tenantId;
     private string? _lastJwtWorkLoadIdentity;
     private DateTimeOffset _lastReadWorkloadIdentity;
+    private readonly string _host;
 
 
     public MsalAuthChanged(IServiceProvider systemServiceProvider, IConfigurationSection msalConfigurationSection)
@@ -26,6 +27,7 @@ public class MsalAuthChanged : IAccessTokenProvider, IMSALProvider
         _clientId = config["AZURE_CLIENT_ID"] ?? throw new NoNullAllowedException("ClientId is required");
         _tenantId = config["AZURE_TENANT_ID"] ?? throw new NoNullAllowedException("TenantId is required");
         _clientSecret = config["ClientSecret"];
+        _host = config["AZURE_AUTHORITY_HOST"];
         _federatedTokenFile = config["AZURE_FEDERATED_TOKEN_FILE"];
     }
 
@@ -82,12 +84,8 @@ public class MsalAuthChanged : IAccessTokenProvider, IMSALProvider
     {
         // initialize the MSAL client
         var cAppBuilder = ConfidentialClientApplicationBuilder
-            .CreateWithApplicationOptions(
-                new ConfidentialClientApplicationOptions
-                {
-                    ClientId = _clientId
-                })
-            .WithLegacyCacheCompatibility(false)
+            .Create(_clientId)
+            .WithAuthority(_host, _tenantId) 
             .WithCacheOptions(new CacheOptions(true));
 
 

--- a/src/Teams.Notifications.Api/MsalAuthChanged.cs
+++ b/src/Teams.Notifications.Api/MsalAuthChanged.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Concurrent;
+using System.Data;
+using Microsoft.Agents.Authentication;
+using Microsoft.Agents.Authentication.Msal;
+using Microsoft.Identity.Client;
+using Teams.Notifications.Api.Services;
+
+namespace Teams.Notifications.Api;
+/// <summary>
+/// Taken from MSAL auth to do this: https://github.com/microsoft/Agents-for-net/pull/228
+/// </summary>
+public class MsalAuthChanged : IAccessTokenProvider, IMSALProvider
+{
+    private readonly ConcurrentDictionary<Uri, AuthResults> _cacheList = new();
+    private readonly string _clientId;
+    private readonly string? _clientSecret;
+    private readonly string? _federatedTokenFile;
+    private readonly string _tenantId;
+    private string? _lastJwtWorkLoadIdentity;
+    private DateTimeOffset _lastReadWorkloadIdentity;
+
+
+    public MsalAuthChanged(IServiceProvider systemServiceProvider, IConfigurationSection msalConfigurationSection)
+    {
+        var config = systemServiceProvider.GetRequiredService<IConfiguration>();
+        _clientId = config["AZURE_CLIENT_ID"] ?? throw new NoNullAllowedException("ClientId is required");
+        _tenantId = config["AZURE_TENANT_ID"] ?? throw new NoNullAllowedException("TenantId is required");
+        _clientSecret = config["ClientSecret"];
+        _federatedTokenFile = config["AZURE_FEDERATED_TOKEN_FILE"];
+    }
+
+
+    public async Task<string> GetAccessTokenAsync(string resourceUrl, IList<string> scopes, bool forceRefresh = false)
+    {
+        if (!Uri.IsWellFormedUriString(resourceUrl, UriKind.RelativeOrAbsolute)) throw new ArgumentException("Invalid instance URL");
+
+        Uri instanceUri = new(resourceUrl);
+        var localScopes = new List<string> { "https://api.botframework.com/.default" }.ToArray();
+
+        // Get or create existing token. 
+        if (_cacheList.ContainsKey(instanceUri))
+        {
+            if (!forceRefresh)
+            {
+                var accessToken = _cacheList[instanceUri].MsalAuthResult.AccessToken;
+                var tokenExpiresOn = _cacheList[instanceUri].MsalAuthResult.ExpiresOn;
+                if (tokenExpiresOn != null && tokenExpiresOn < DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)))
+                {
+                    accessToken = string.Empty; // flush the access token if it is about to expire.
+                    _cacheList.Remove(instanceUri, out _);
+                }
+
+                if (!string.IsNullOrEmpty(accessToken)) return accessToken;
+            }
+            else
+                _cacheList.Remove(instanceUri, out _);
+        }
+
+        var msalAuthClient = InnerCreateClientApplication();
+
+        if (localScopes.Length == 0) throw new ArgumentException("At least one Scope is required for Client Authentication.");
+
+        var authResult = await msalAuthClient.AcquireTokenForClient(localScopes).WithForceRefresh(true).ExecuteAsync().ConfigureAwait(false);
+        var authResultPayload = new AuthResults
+        {
+            MsalAuthResult = authResult,
+            TargetServiceUrl = instanceUri,
+            MsalAuthClient = msalAuthClient
+        };
+
+        if (_cacheList.ContainsKey(instanceUri))
+            _cacheList[instanceUri] = authResultPayload;
+        else
+            _cacheList.TryAdd(instanceUri, authResultPayload);
+
+        return authResultPayload.MsalAuthResult.AccessToken;
+    }
+
+    public IApplicationBase CreateClientApplication() => InnerCreateClientApplication();
+
+    private IConfidentialClientApplication InnerCreateClientApplication()
+    {
+        // initialize the MSAL client
+        var cAppBuilder = ConfidentialClientApplicationBuilder
+            .CreateWithApplicationOptions(
+                new ConfidentialClientApplicationOptions
+                {
+                    ClientId = _clientId
+                })
+            .WithLegacyCacheCompatibility(false)
+            .WithCacheOptions(new CacheOptions(true));
+
+
+        cAppBuilder.WithTenantId(_tenantId);
+
+        if (!string.IsNullOrWhiteSpace(_clientSecret))
+            cAppBuilder.WithClientSecret(_clientSecret);
+        else
+            cAppBuilder.WithClientAssertion(() =>
+            {
+                // read only once every 5 minutes, less heavy for I/O
+                if (_lastJwtWorkLoadIdentity != null && DateTimeOffset.UtcNow.Subtract(_lastReadWorkloadIdentity) <= TimeSpan.FromMinutes(5))
+                    return _lastJwtWorkLoadIdentity;
+                _lastReadWorkloadIdentity = DateTimeOffset.UtcNow;
+                _lastJwtWorkLoadIdentity = File.ReadAllText(_federatedTokenFile!);
+                return _lastJwtWorkLoadIdentity;
+            });
+
+        return cAppBuilder.Build();
+    }
+}

--- a/src/Teams.Notifications.Api/Program.cs
+++ b/src/Teams.Notifications.Api/Program.cs
@@ -30,17 +30,9 @@ var clientId = builder.Configuration["AZURE_CLIENT_ID"] ?? throw new NoNullAllow
 var tenantId = builder.Configuration["AZURE_TENANT_ID"] ?? throw new NoNullAllowedException("TenantId is required");
 var clientSecret = builder.Configuration["ClientSecret"];
 
-var inMemoryItems = new Dictionary<string, string?>
-{
-    { "TokenValidation:Audiences:0", clientId },
-    { "TokenValidation:TenantId", tenantId },
-};
 // will use workload if available
 TokenCredential credentials = new DefaultAzureCredential();
-
-
 if (!string.IsNullOrWhiteSpace(clientSecret)) credentials = new ClientSecretCredential(tenantId, clientId, clientSecret);
-builder.Configuration.AddInMemoryCollection(inMemoryItems);
 builder.Services.AddSingleton(new GraphServiceClient(credentials));
 builder.Services.AddTransient<RequestAndResponseLoggerHandler>();
 builder.Services.AddTransient<IFileErrorManagerService, FileErrorManagerService>();

--- a/src/Teams.Notifications.Api/Program.cs
+++ b/src/Teams.Notifications.Api/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddKernel();
 // Values from app registration
 var clientId = builder.Configuration["AZURE_CLIENT_ID"] ?? throw new NoNullAllowedException("ClientId is required");
 var tenantId = builder.Configuration["AZURE_TENANT_ID"] ?? throw new NoNullAllowedException("TenantId is required");
+var host = builder.Configuration["AZURE_AUTHORITY_HOST"] ?? throw new NoNullAllowedException("host is required");
 var clientSecret = builder.Configuration["ClientSecret"];
 
 // will use workload if available

--- a/src/Teams.Notifications.Api/Program.cs
+++ b/src/Teams.Notifications.Api/Program.cs
@@ -5,16 +5,13 @@ using System.Text.Json.Serialization;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Agents.Storage;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Teams.Notifications.Api;
 using Teams.Notifications.Api.Agents;
 using Teams.Notifications.Api.DelegatingHandlers;
 using Teams.Notifications.Api.Middlewares;
 using Teams.Notifications.Api.Services;
-using Teams.Notifications.Api.Telemetry;
 using IMiddleware = Microsoft.Agents.Builder.IMiddleware;
 using WebApplication = Microsoft.AspNetCore.Builder.WebApplication;
 
@@ -33,37 +30,16 @@ var clientId = builder.Configuration["AZURE_CLIENT_ID"] ?? throw new NoNullAllow
 var tenantId = builder.Configuration["AZURE_TENANT_ID"] ?? throw new NoNullAllowedException("TenantId is required");
 var clientSecret = builder.Configuration["ClientSecret"];
 
-const string svName = "ServiceConnection";
-const string ConnectionSettings = $"Connections:{svName}:Settings";
 var inMemoryItems = new Dictionary<string, string?>
 {
     { "TokenValidation:Audiences:0", clientId },
     { "TokenValidation:TenantId", tenantId },
-    // ConnectionsMap with the ServiceConnection
-    { "ConnectionsMap:0:ServiceUrlSettings", "*" },
-    { "ConnectionsMap:0:Connection", svName },
-    // ServiceConnection
-    { $"{ConnectionSettings}:AuthorityEndpoint", "https://login.microsoftonline.com/" + tenantId },
-    { $"{ConnectionSettings}:ClientId", clientId },
-    { $"{ConnectionSettings}:Scopes:0", "https://api.botframework.com/.default" }
 };
 // will use workload if available
 TokenCredential credentials = new DefaultAzureCredential();
-// no secret so Federate
-if (string.IsNullOrWhiteSpace(clientSecret))
-{
-    // ServiceConnection, for workload id
-    inMemoryItems.Add($"{ConnectionSettings}:AuthType", "FederatedCredentials");
-    inMemoryItems.Add($"{ConnectionSettings}:FederatedClientId", clientId);
-}
-else
-{
-    // ServiceConnection, for env with secret
-    inMemoryItems.Add($"{ConnectionSettings}:AuthType", "ClientSecret");
-    inMemoryItems.Add($"{ConnectionSettings}:ClientSecret", clientSecret);
-    credentials = new ClientSecretCredential(tenantId, clientId, clientSecret);
-}
 
+
+if (!string.IsNullOrWhiteSpace(clientSecret)) credentials = new ClientSecretCredential(tenantId, clientId, clientSecret);
 builder.Configuration.AddInMemoryCollection(inMemoryItems);
 builder.Services.AddSingleton(new GraphServiceClient(credentials));
 builder.Services.AddTransient<RequestAndResponseLoggerHandler>();

--- a/src/Teams.Notifications.Api/Services/AuthResults.cs
+++ b/src/Teams.Notifications.Api/Services/AuthResults.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client;
+
+namespace Teams.Notifications.Api.Services;
+
+internal sealed class AuthResults
+{
+    public AuthenticationResult MsalAuthResult { get; set; }
+    public Uri TargetServiceUrl { get; set; }
+    public object MsalAuthClient { get; set; }
+}

--- a/src/Teams.Notifications.Api/appsettings.json
+++ b/src/Teams.Notifications.Api/appsettings.json
@@ -15,5 +15,17 @@
     "StartTypingTimer": false,
     "RemoveRecipientMention": false,
     "NormalizeMentions": false
+  },
+  "ConnectionsMap": [
+    {
+      "ServiceUrl": "*",
+      "Connection": "ServiceConnection"
+    }
+  ],
+  "Connections": {
+    "ServiceConnection": {
+      "Assembly": "Teams.Notifications.Api",
+      "Type": "MsalAuthChanged"
+    }
   }
 }

--- a/src/Teams.Notifications.Api/appsettings.local.json
+++ b/src/Teams.Notifications.Api/appsettings.local.json
@@ -7,5 +7,6 @@
   },
   "AZURE_CLIENT_ID": "c911e027-3cbc-4614-9f2e-872c20b8f4b2",
   "AZURE_TENANT_ID": "8421dd92-337e-4405-8cfc-16118ffc5715",
+  "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
   "ClientSecret": "CHANGE_ME"
 }


### PR DESCRIPTION
1. Use the assembly loader to load our own version of MSALauth that can handle the workidenity flow
2. remove some of the policies around who can access our API, but do make sure that we still auth the api/messages endpoint, for now the filerror controller is open!!!
3. Make errormessage optional
4. Cleanup the config