### PR TITLE
AB#93251: Update Azure secrets to new Entra naming convention

### DIFF
--- a/.github/workflows/api-cd.yaml
+++ b/.github/workflows/api-cd.yaml
@@ -24,7 +24,7 @@ jobs:
   TeamsNotificationsApi_CD:
     uses: ./.github/workflows/shared-app-cd-workflow.yaml
     secrets:
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.ENTRA_PROD_WORKFORCE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_PLATFORM_SUBSCRIPTION_ID: ${{ secrets.AZURE_PLATFORM_SUBSCRIPTION_ID }}
       AZURE_DEV_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEV_SUBSCRIPTION_ID }}


### PR DESCRIPTION
Updates AZURE_TENANT_ID to ENTRA_PROD_WORKFORCE_TENANT_ID in CD workflows per [AB#93251](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/93251)